### PR TITLE
Duct-tape solution for compiling with clang, replace --fast-math with…

### DIFF
--- a/configs/repos/ufs/packages/wgrib2/package.py
+++ b/configs/repos/ufs/packages/wgrib2/package.py
@@ -128,6 +128,10 @@ class Wgrib2(MakefilePackage):
         makefile.filter(r'-openmp', '-qopenmp')
         makefile.filter(r'-Wall', ' ')
 
+        # clang doesn't understand --fast-math
+        if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
+            makefile.filter(r'--fast-math', '-ffast-math')
+
         for variant_name, makefile_option in self.variant_map.items():
             value = int(spec.variants[variant_name].value)
             makefile.filter(r'^%s=.*' % makefile_option,


### PR DESCRIPTION
@kgerheiser This is a duct-tape solution [for compiling with clang, simply replace all occurrences of `--fast-math` with `-ffast-math` in the top-level `makefile`. With this change, I can build wgrib2 (and run it) with your branch.

Note. I am not sure if the change is only required for `clang` (=`llvm-clang`) or also for `apple-clang`. I added it for both.
